### PR TITLE
Fix flaky

### DIFF
--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -283,6 +283,7 @@ public class TestGenerateJsonSchema
 
         Map<String, Object> result = writeAndMap(mapper, jsonSchema);
         assertNotNull(result);
+        
         String schemaString = mapper.writeValueAsString(jsonSchema);
         assertEquals("{\"type\":\"object\"," +
                 "\"dependencies\":{\"property1\":[\"property2\"]}," +

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -133,7 +133,6 @@ public class TestGenerateJsonSchema
      */
 
     private final ObjectMapper MAPPER = new ObjectMapper();
-    
 
     /**
      * Test simple generation

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
@@ -132,6 +133,7 @@ public class TestGenerateJsonSchema
      */
 
     private final ObjectMapper MAPPER = new ObjectMapper();
+    
 
     /**
      * Test simple generation
@@ -274,33 +276,26 @@ public class TestGenerateJsonSchema
     }
 
     public void testSinglePropertyDependency() throws Exception {
-        JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(mapper);
         JsonSchema jsonSchema = generator.generateSchema(SimpleBean.class);
         ((ObjectSchema) jsonSchema).addSimpleDependency("property1", "property2");
 
-        Map<String, Object> result = writeAndMap(MAPPER, jsonSchema);
+        Map<String, Object> result = writeAndMap(mapper, jsonSchema);
         assertNotNull(result);
-
-        String schemaString = MAPPER.writeValueAsString(jsonSchema);
-        String possibleString1 = "{\"type\":\"object\"," +
-                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
+        
+        String schemaString = mapper.writeValueAsString(jsonSchema);
+        assertEquals("{\"type\":\"object\"," +
                 "\"dependencies\":{\"property1\":[\"property2\"]}," +
-                "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
-                ",\"property2\":{\"type\":\"string\"}," +
-                "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
-                "\"property4\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}," +
-                "\"property5\":{\"type\":\"string\",\"required\":true}}}";
-        String possibleString2 = "{\"type\":\"object\"," +
                 "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
                 ",\"property2\":{\"type\":\"string\"}," +
                 "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
                 "\"property4\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}," +
-                "\"property5\":{\"type\":\"string\",\"required\":true}}," +
-                "\"dependencies\":{\"property1\":[\"property2\"]}}";
-        assertTrue(possibleString1.equals(schemaString) || possibleString2.equals(schemaString));
+                "\"property5\":{\"type\":\"string\",\"required\":true}}}", schemaString);
     }
-
+    
     public void testMultiplePropertyDependencies() throws Exception {
         JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER);
         JsonSchema jsonSchema = generator.generateSchema(SimpleBean.class);

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -295,22 +295,24 @@ public class TestGenerateJsonSchema
                 "\"property4\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}," +
                 "\"property5\":{\"type\":\"string\",\"required\":true}}}", schemaString);
     }
-    
+
     public void testMultiplePropertyDependencies() throws Exception {
-        JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(mapper);
         JsonSchema jsonSchema = generator.generateSchema(SimpleBean.class);
         ((ObjectSchema) jsonSchema).addSimpleDependency("property1", "property2");
         ((ObjectSchema) jsonSchema).addSimpleDependency("property1", "property3");
         ((ObjectSchema) jsonSchema).addSimpleDependency("property1", "property2");
         ((ObjectSchema) jsonSchema).addSimpleDependency("property2", "property3");
 
-        Map<String, Object> result = writeAndMap(MAPPER, jsonSchema);
+        Map<String, Object> result = writeAndMap(mapper, jsonSchema);
         assertNotNull(result);
 
-        String schemaString = MAPPER.writeValueAsString(jsonSchema);
+        String schemaString = mapper.writeValueAsString(jsonSchema);
         assertEquals("{\"type\":\"object\"," +
-                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"dependencies\":{\"property1\":[\"property2\",\"property3\"],\"property2\":[\"property3\"]}," +
+                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
                 ",\"property2\":{\"type\":\"string\"}," +
                 "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
@@ -319,7 +321,9 @@ public class TestGenerateJsonSchema
     }
 
     public void testSchemaPropertyDependency() throws Exception {
-        JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(mapper);
 
         // Given this dependency schema
         JsonSchema schemaPropertyDependency = generator.generateSchema(DependencySchema.class);
@@ -328,14 +332,14 @@ public class TestGenerateJsonSchema
         JsonSchema simpleBeanSchema = generator.generateSchema(SimpleBean.class);
         ((ObjectSchema) simpleBeanSchema).addSchemaDependency("property1", schemaPropertyDependency);
 
-        Map<String, Object> result = writeAndMap(MAPPER, simpleBeanSchema);
+        Map<String, Object> result = writeAndMap(mapper, simpleBeanSchema);
         assertNotNull(result);
 
         // Test the generated value.
-        String schemaString = MAPPER.writeValueAsString(simpleBeanSchema);
+        String schemaString = mapper.writeValueAsString(simpleBeanSchema);
         assertEquals("{\"type\":\"object\"," +
-                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"dependencies\":{\"property1\":{\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:DependencySchema\",\"properties\":{\"property2\":{\"type\":\"string\",\"required\":true}}}}," +
+                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
                 ",\"property2\":{\"type\":\"string\"}," +
                 "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
@@ -344,7 +348,9 @@ public class TestGenerateJsonSchema
     }
 
     public void testSchemaPropertyDependencies() throws Exception {
-        JsonSchemaGenerator generator = new JsonSchemaGenerator(MAPPER);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        JsonSchemaGenerator generator = new JsonSchemaGenerator(mapper);
 
         // Given this dependency schema
         JsonSchema schemaPropertyDependency = generator.generateSchema(DependencySchema.class);
@@ -354,18 +360,18 @@ public class TestGenerateJsonSchema
         ((ObjectSchema) simpleBeanSchema).addSchemaDependency("property1", schemaPropertyDependency);
         ((ObjectSchema) simpleBeanSchema).addSchemaDependency("property3", schemaPropertyDependency);
 
-        Map<String, Object> result = writeAndMap(MAPPER, simpleBeanSchema);
+        Map<String, Object> result = writeAndMap(mapper, simpleBeanSchema);
         assertNotNull(result);
 
         // Test the generated value.
-        String schemaString = MAPPER.writeValueAsString(simpleBeanSchema);
+        String schemaString = mapper.writeValueAsString(simpleBeanSchema);
         assertEquals(
                 "{" +
                   "\"type\":\"object\"," +
-                  "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                   "\"dependencies\":{" +
                     "\"property1\":{\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:DependencySchema\",\"properties\":{\"property2\":{\"type\":\"string\",\"required\":true}}}," +
                     "\"property3\":{\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:DependencySchema\",\"properties\":{\"property2\":{\"type\":\"string\",\"required\":true}}}}," +
+                  "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                   "\"properties\":{" +
                       "\"property1\":{\"type\":\"integer\"}" +
                       ",\"property2\":{\"type\":\"string\"}," +

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -2,6 +2,7 @@ package com.fasterxml.jackson.module.jsonSchema;
 
 import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -19,6 +20,7 @@ import java.util.Map;
 public class TestGenerateJsonSchema
     extends SchemaTestBase
 {
+    @JsonPropertyOrder({"property1", "property2", "property3", "property4", "property5"})
     public static class SimpleBean
     {
         private int property1;
@@ -280,14 +282,23 @@ public class TestGenerateJsonSchema
         assertNotNull(result);
 
         String schemaString = MAPPER.writeValueAsString(jsonSchema);
-        assertEquals("{\"type\":\"object\"," +
+        String possibleString1 = "{\"type\":\"object\"," +
                 "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
                 "\"dependencies\":{\"property1\":[\"property2\"]}," +
                 "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
                 ",\"property2\":{\"type\":\"string\"}," +
                 "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
                 "\"property4\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}," +
-                "\"property5\":{\"type\":\"string\",\"required\":true}}}", schemaString);
+                "\"property5\":{\"type\":\"string\",\"required\":true}}}";
+        String possibleString2 = "{\"type\":\"object\"," +
+                "\"id\":\"urn:jsonschema:com:fasterxml:jackson:module:jsonSchema:TestGenerateJsonSchema:SimpleBean\"," +
+                "\"properties\":{\"property1\":{\"type\":\"integer\"}" +
+                ",\"property2\":{\"type\":\"string\"}," +
+                "\"property3\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}}," +
+                "\"property4\":{\"type\":\"array\",\"items\":{\"type\":\"number\"}}," +
+                "\"property5\":{\"type\":\"string\",\"required\":true}}," +
+                "\"dependencies\":{\"property1\":[\"property2\"]}}";
+        assertTrue(possibleString1.equals(schemaString) || possibleString2.equals(schemaString));
     }
 
     public void testMultiplePropertyDependencies() throws Exception {

--- a/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
+++ b/src/test/java/com/fasterxml/jackson/module/jsonSchema/TestGenerateJsonSchema.java
@@ -283,7 +283,6 @@ public class TestGenerateJsonSchema
 
         Map<String, Object> result = writeAndMap(mapper, jsonSchema);
         assertNotNull(result);
-        
         String schemaString = mapper.writeValueAsString(jsonSchema);
         assertEquals("{\"type\":\"object\"," +
                 "\"dependencies\":{\"property1\":[\"property2\"]}," +


### PR DESCRIPTION
These 5 properties in the schema may appear in different orders, and the property and dependency may appear in different orders as well. I added @JsonPropertyOrder to make the properties in a deterministic order and added two different possible orders in which dependency and property may appear.